### PR TITLE
Fix biases for "test-variations": ["Disabled", "Enabled"]

### DIFF
--- a/FeatureFlags/Classes/Model/Feature+Codable.swift
+++ b/FeatureFlags/Classes/Model/Feature+Codable.swift
@@ -62,7 +62,11 @@ extension Feature: Codable {
                 if Feature.testVariationsContains(variationNames: ["enabled", "disabled"], in: testVariations)
                     || Feature.testVariationsContains(variationNames: ["on", "off"], in: testVariations) {
                     self.type = type ?? .featureTest(.featureFlagAB)
-                    self.testVariations = defaultTestVariations
+                    if ["disabled", "off"].contains(testVariations.first?.rawValue.lowercased()) {
+                        self.testVariations = defaultTestVariations.reversed()
+                    } else {
+                        self.testVariations = defaultTestVariations
+                    }
                 } else {
                     self.type = type ?? .featureTest(.ab)
                     self.testVariations = testVariations


### PR DESCRIPTION
Hi @rwbutler, Thanks for your work!

I think I found a small corner case when assigning ```"test-variations": ["Disabled", "Enabled"]``` instead of ```"test-variations": ["Enabled", "Disabled"]```. When the order is reversed, biases aren't reversed. Not a big deal, but it could be annoying to release a feature to 90% of users, thinking only 10% would be impacted.

For example, with the following feature file:
```
{
    "features": [{
        "name": "Example Feature Flag",
        "enabled": true,
        "test-variations": ["Disabled", "Enabled"],
        "test-biases":[90, 10]
    }]
}
```

Calling ```Feature.named(.exampleFeatureFlag)!.description``` results in the following:
```
Feature: Example Feature Flag
Enabled: false
Test variations: Enabled (90.0%), Disabled (10.0%)
Test variation assignment: 93% -> Disabled
```

The same behaviour occurs with Off/On instead of Disabled/Enabled.

I made a quick and dirty patch for it, which preserves the method ```testVariationsContains``` in case you planned to use it for other use cases. It's not the most elegant way, but it seems to do the trick.